### PR TITLE
improved Formatter usage #16

### DIFF
--- a/src/Flintstone/FlintstoneDB.php
+++ b/src/Flintstone/FlintstoneDB.php
@@ -157,13 +157,16 @@ class FlintstoneDB
             $this->gzip_enabled = !$this->gzip_enabled;
         }
 
+        if (! is_null($options['formatter']) && ! $options['formatter'] instanceof FormatterInterface) {
+            throw new FlintstoneException("Formatter must implement Flintstone\Formatter\FormatterInterface");
+        }
+        $this->formatter = $options['formatter'] ?: new Formatter\SerializeFormatter;
+
         $extension = filter_var(
             $options['ext'],
             FILTER_SANITIZE_STRING,
             array('flags' => FILTER_FLAG_STRIP_LOW|FILTER_FLAG_STRIP_HIGH)
         );
-
-        $this->setFormatter($options['formatter']);
         $this->setFile($dir, $database, $extension);
     }
 
@@ -333,18 +336,6 @@ class FlintstoneDB
     public function getFile()
     {
         return $this->file;
-    }
-
-    /**
-     * Set the formatter used to encode/decode data
-     *
-     * @param \Flintstone\Formatter\FormatterInterface $formatter the formatter class
-     *
-     * @return void
-     */
-    private function setFormatter(FormatterInterface $formatter = null)
-    {
-        $this->formatter = $formatter ?: new Formatter\SerializeFormatter;
     }
 
     /**

--- a/tests/TestFixture.php
+++ b/tests/TestFixture.php
@@ -9,6 +9,7 @@ namespace Flinstone\tests;
 use Flintstone\Flintstone;
 use Flintstone\FlintstoneException;
 use Flintstone\Formatter\JsonFormatter;
+use stdClass;
 
 class TestFixture extends \PHPUnit_Framework_TestCase
 {
@@ -54,7 +55,7 @@ class TestFixture extends \PHPUnit_Framework_TestCase
     {
         Flintstone::load('blah', array(
             'dir'   => __DIR__,
-            'formatter' => new \stdClass()
+            'formatter' => new stdClass
         ));
     }
 
@@ -63,9 +64,9 @@ class TestFixture extends \PHPUnit_Framework_TestCase
      */
     public function testSameInstance()
     {
-        $db = Flintstone::load($this->dbName, array('dir' => __DIR__));
+        $db1 = Flintstone::load($this->dbName, array('dir' => __DIR__));
         $db2 = Flintstone::load($this->dbName, array('dir' => __DIR__));
-        $this->assertSame($db, $db2);
+        $this->assertSame($db1, $db2);
     }
 
     /**


### PR DESCRIPTION
I've removed the `setFormatter` method and everything is check directly in the constructor using Type hinting this pull request addresses the issue #16 
