### PR TITLE
Deprecate the replace method

### DIFF
--- a/src/Flintstone/FlintstoneDB.php
+++ b/src/Flintstone/FlintstoneDB.php
@@ -159,7 +159,7 @@ class FlintstoneDB
         } elseif (! is_null($options['formatter']) && ! $options['formatter'] instanceof FormatterInterface) {
             throw new FlintstoneException("Formatter must implement Flintstone\Formatter\FormatterInterface");
         }
-        $this->formatter = $options['formatter'] ?: new Formatter\SerializeFormatter;
+        $this->formatter = $options['formatter'] ?: new SerializeFormatter;
 
         $this->swap_memory_limit = filter_var(
             $options['swap_memory_limit'],


### PR DESCRIPTION
- the replace method is deprecated and can be safely remove when the package move to the next major version (ie: go version 2.0.0) #17 
- Interval code improvements:
  - Encoding/decoding is cleanly decoupled from FlintstoneDB
  - Remove other useless methods
