### PR TITLE
Document easier installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,10 @@ For full documentation please visit http://www.xeweb.net/flintstone/
 
 ### Installation
 
-The easiest way to install Flintstone is via [composer](http://getcomposer.org/). Create the following `composer.json` file and run the `php composer.phar install` command to install it.
+The easiest way to install Flintstone is via [composer](http://getcomposer.org/). Run the following command to install it.
 
-```json
-{
-    "require": {
-        "fire015/flintstone": "1.*"
-    }
-}
+```
+php composer.phar require fire015/flintstone
 ```
 
 ```php


### PR DESCRIPTION
The `composer require` command takes care of creating the `composer.json` file for you, or appropriately adding the dependency to an existing file, and then downloading the dependency. So rather than faffing about with files and then running the `install` command, the user only needs to run single `require` command.
