### PR TITLE
Improve Config class

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Flintstone can store the following data types:
 
 |Name				|Type		|Default Value	|Description														|
 |---				|---		|---				|---														|
-|dir				|string				|''			|The directory where the database files are stored (this should be somewhere that is not web accessible) e.g. /path/to/database/			|
-|ext				|string				|.dat		|The database file extension to use							|
+|directory				|string				|''			|The directory where the database files are stored (this should be somewhere that is not web accessible) e.g. /path/to/database/			|
+|extension				|string				|.dat		|The database file extension to use							|
 |gzip				|boolean			|false		|Use gzip to compress the database							|
-|cache				|boolean or object	|true		|Whether to cache `get()` results for faster data retrieval								|
-|formatter			|null or object		|null		|The formatter class used to encode/decode data				|
+|cache				|CacheInterface	|ArrayCache		|Whether to cache `get()` results for faster data retrieval								|
+|formatter			|FormatterInterface		|SerializeFormatter		|The formatter class used to encode/decode data				|
 |swap_memory_limit	|integer			|2097152	|The amount of memory to use before writing to a temporary file	|
 
 
@@ -63,7 +63,7 @@ Flintstone can store the following data types:
 
 ```php
 // Set options
-$options = array('dir' => '/path/to/database/dir/');
+$options = array('directory' => '/path/to/database/dir/');
 
 // Load the databases
 $users = new Flintstone('users', $options);
@@ -116,7 +116,7 @@ use Flintstone\Flintstone;
 use Flintstone\Formatter\JsonFormatter;
 
 $users = new Flintstone('users', array(
-	'dir' => __DIR__,
+	'directory' => __DIR__,
 	'formatter' => new JsonFormatter
 ));
 ```
@@ -141,7 +141,7 @@ $cache = new MemcachedCache;
 $cache->setMemcached($memcached);
 
 $users = new Flintstone('users', array(
-	'dir' => __DIR__,
+	'directory' => __DIR__,
 	'cache' => $cache
 ));
 ```

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
     },
     "require-dev" : {
         "phpunit/phpunit": "~4.0"
+    },
+    "scripts": {
+        "test": "phpunit --coverage-text"
     }
 }

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Flintstone package.
+ *
+ * (c) Jason M <emailfire@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+namespace Flintstone\Cache;
+
+class NullCache implements CacheInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function contains($key)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $data)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($key)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+    }
+}

--- a/src/Flintstone.php
+++ b/src/Flintstone.php
@@ -34,7 +34,7 @@ class Flintstone
      */
     public function __construct(Database $database)
     {
-        $this->setDatabase($database);
+        $this->database = $database;
     }
 
     /**
@@ -58,16 +58,6 @@ class Flintstone
     public function getDatabase()
     {
         return $this->database;
-    }
-
-    /**
-     * Set the database.
-     *
-     * @param Database $database
-     */
-    public function setDatabase(Database $database)
-    {
-        $this->database = $database;
     }
 
     /**

--- a/tests/Cache/NullCacheTest.php
+++ b/tests/Cache/NullCacheTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Flintstone\Cache\NullCache;
+
+/**
+ * @group cache
+ */
+class NullCacheTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider nullCacheProvider
+     */
+    public function testGetter($param, $value)
+    {
+        $cache = new NullCache();
+        $cache->set($param, $value);
+        $this->assertFalse($cache->contains($param));
+        $this->assertNull($cache->get($param));
+    }
+
+    public function nullCacheProvider()
+    {
+        return array(
+            array('test', 'toto'),
+            array('foo', array('bar', 'baz')),
+        );
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,45 +1,49 @@
 <?php
 
+use Flintstone\Cache\NullCache;
 use Flintstone\Config;
 use Flintstone\Formatter\JsonFormatter;
 
+/**
+ * @group config
+ */
 class ConfigTest extends PHPUnit_Framework_TestCase
 {
     public function testDefaultConfig()
     {
         $config = new Config();
-        $this->assertEquals(getcwd() . DIRECTORY_SEPARATOR, $config->getDir());
-        $this->assertEquals('.dat', $config->getExt());
+        $this->assertEquals(getcwd() . DIRECTORY_SEPARATOR, $config->getDirectory());
+        $this->assertEquals('.dat', $config->getExtension());
         $this->assertFalse($config->useGzip());
-        $this->assertInstanceOf('Flintstone\Cache\ArrayCache', $config->getCache());
-        $this->assertInstanceOf('Flintstone\Formatter\SerializeFormatter', $config->getFormatter());
+        $this->assertInstanceOf('Flintstone\Cache\CacheInterface', $config->getCache());
+        $this->assertInstanceOf('Flintstone\Formatter\FormatterInterface', $config->getFormatter());
         $this->assertEquals(2097152, $config->getSwapMemoryLimit());
     }
 
-    public function testConfigConstructorOptions()
-    {
-        $config = new Config(array(
-            'dir' => __DIR__,
-            'ext' => 'test',
-            'gzip' => true,
-            'cache' => true,
-            'formatter' => null,
-            'swap_memory_limit' => 100,
-        ));
-
-        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR, $config->getDir());
-        $this->assertEquals('.test.gz', $config->getExt());
-        $this->assertTrue($config->useGzip());
-        $this->assertInstanceOf('Flintstone\Cache\ArrayCache', $config->getCache());
-        $this->assertInstanceOf('Flintstone\Formatter\SerializeFormatter', $config->getFormatter());
-        $this->assertEquals(100, $config->getSwapMemoryLimit());
-    }
-
-    public function testConfigSetFormatter()
+    public function testImmutabilityWithTheSameSettings()
     {
         $config = new Config();
-        $config->setFormatter(new JsonFormatter());
-        $this->assertInstanceOf('Flintstone\Formatter\JsonFormatter', $config->getFormatter());
+        $alt = $config
+            ->withExtension($config->getExtension())
+            ->withDirectory($config->getDirectory())
+            ->withGzip($config->useGzip())
+            ->withCache($config->getCache())
+            ->withFormatter($config->getFormatter())
+            ->withSwapMemoryLimit($config->getSwapMemoryLimit());
+        $this->assertSame($alt, $config);
+    }
+
+    public function testImmutabilityWithUpdatedSettings()
+    {
+        $config = new Config();
+        $alt = $config
+            ->withFormatter(new JsonFormatter())
+            ->withExtension('db')
+            ->withDirectory(__DIR__)
+            ->withGzip(true)
+            ->withCache(new NullCache())
+            ->withSwapMemoryLimit(100);
+        $this->assertNotSame($alt, $config);
     }
 
     /**
@@ -48,24 +52,24 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     public function testConfigInvalidDir()
     {
         $config = new Config();
-        $config->setDir('/x/y/z/foo');
+        $config->withDirectory('/x/y/z/foo');
     }
 
     /**
      * @expectedException Flintstone\Exception
      */
-    public function testConfigInvalidFormatter()
+    public function testConfigInvalidDirOnPermission()
     {
         $config = new Config();
-        $config->setFormatter(new self());
+        $config->withDirectory('/');
     }
 
     /**
      * @expectedException Flintstone\Exception
      */
-    public function testConfigInvalidCache()
+    public function testConfigInvalidSwapMemory()
     {
         $config = new Config();
-        $config->setCache(new self());
+        $config->withSwapMemoryLimit(0);
     }
 }

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -3,8 +3,16 @@
 use Flintstone\Config;
 use Flintstone\Database;
 
+/**
+ * @group database
+ */
 class DatabaseTest extends PHPUnit_Framework_TestCase
 {
+    public function tearDown()
+    {
+        @unlink(getcwd().'/test.dat');
+    }
+
     /**
      * @expectedException Flintstone\Exception
      */
@@ -17,7 +25,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     public function testGetDatabaseAndConfig()
     {
         $config = new Config(array(
-            'dir' => __DIR__,
+            'directory' => __DIR__,
         ));
 
         $path = __DIR__ . DIRECTORY_SEPARATOR . 'test.dat';
@@ -26,5 +34,24 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('test', $db->getName());
         $this->assertInstanceOf('Flintstone\Config', $db->getConfig());
         $this->assertEquals($path, $db->getPath());
+    }
+
+    public function testNameImmutability()
+    {
+        $db = new Database('test', new Config());
+        $this->assertSame($db, $db->withName('test'));
+        $this->assertNotEquals($db, $db->withName('tacos'));
+    }
+
+
+    public function testConfigImmutability()
+    {
+        $config = new Config();
+        $sameConfig = $config->withExtension('.dat');
+        $altConfig = $config->withExtension('db');
+
+        $db = new Database('test', $config);
+        $this->assertSame($db, $db->withConfig($sameConfig));
+        $this->assertNotEquals($db, $db->withConfig($altConfig));
     }
 }

--- a/tests/FlintstoneTest.php
+++ b/tests/FlintstoneTest.php
@@ -1,10 +1,21 @@
 <?php
 
 use Flintstone\Flintstone;
+use Flintstone\Cache\ArrayCache;
+use Flintstone\Cache\NullCache;
 use Flintstone\Formatter\JsonFormatter;
 
+/**
+ * @group flintstone
+ * @group database
+ */
 class FlintstoneTest extends PHPUnit_Framework_TestCase
 {
+    public function tearDown()
+    {
+        @unlink(getcwd().'/test.dat');
+    }
+
     /**
      * @expectedException Flintstone\Exception
      */
@@ -20,70 +31,154 @@ class FlintstoneTest extends PHPUnit_Framework_TestCase
     public function testKeyInvalidData()
     {
         $db = Flintstone::load('test');
-        $db->set('test', new self());
+        $db->set('test', (object) array());
     }
 
-    public function testOperations()
+    public function testDatabaseProvider()
     {
-        $this->runOperationsTests(array(
-            'dir' => __DIR__,
-            'cache' => false,
-            'gzip' => false,
-        ));
-
-        $this->runOperationsTests(array(
-            'dir' => __DIR__,
-            'cache' => true,
-            'gzip' => true,
-        ));
-
-        $this->runOperationsTests(array(
-            'dir' => __DIR__,
-            'cache' => false,
-            'gzip' => false,
-            'formatter' => new JsonFormatter(),
-        ));
+        return array(
+            'no cache, no gzip' => array(
+                'no-cache-no-gizp',
+                array(
+                    'dir' => __DIR__,
+                    'cache' => new NullCache(),
+                    'gzip' => false,
+                ),
+            ),
+            'with cache, with gzip' => array(
+                'with-cache-with-gzip',
+                array(
+                    'dir' => __DIR__,
+                    'cache' => new ArrayCache(),
+                    'gzip' => true,
+                ),
+            ),
+            'no cache, no gzip, alt formatter' => array(
+                'alt-formatter',
+                array(
+                    'dir' => __DIR__,
+                    'cache' => new NullCache(),
+                    'gzip' => false,
+                    'formatter' => new JsonFormatter(),
+                ),
+            ),
+        );
     }
 
-    protected function runOperationsTests($config)
+    /**
+     * @dataProvider testDatabaseProvider
+     */
+    public function testSetGet($dbname, $config)
     {
-        $db = Flintstone::load('test', $config);
+        $db = Flintstone::load($dbname, $config);
+
         $arr = array('foo' => "new\nline");
-
-        $this->assertFalse($db->get('foo'));
-
         $db->set('foo', 1);
         $db->set('name', 'john');
         $db->set('arr', $arr);
+
         $this->assertEquals(1, $db->get('foo'));
         $this->assertEquals('john', $db->get('name'));
         $this->assertEquals($arr, $db->get('arr'));
+        unlink($db->getDatabase()->getPath());
+    }
 
+    /**
+     * @dataProvider testDatabaseProvider
+     */
+    public function testGetCached($dbname, $config)
+    {
+        $db = Flintstone::load($dbname, $config);
+        $db->set('foo', 1);
+        $this->assertEquals(1, $db->get('foo'));
+        $this->assertEquals(1, $db->get('foo'));
+        unlink($db->getDatabase()->getPath());
+    }
+
+    /**
+     * @dataProvider testDatabaseProvider
+     */
+    public function testGetUnkownValue($dbname, $config)
+    {
+        $db = Flintstone::load($dbname, $config);
+        $this->assertFalse($db->get('foo'));
+        unlink($db->getDatabase()->getPath());
+    }
+
+    /**
+     * @dataProvider testDatabaseProvider
+     */
+    public function testUpdateAValue($dbname, $config)
+    {
+        $db = Flintstone::load($dbname, $config);
+        $db->set('foo', 1);
+        $this->assertEquals(1, $db->get('foo'));
         $db->set('foo', 2);
         $this->assertEquals(2, $db->get('foo'));
-        $this->assertEquals('john', $db->get('name'));
-        $this->assertEquals($arr, $db->get('arr'));
+        unlink($db->getDatabase()->getPath());
+    }
 
-        $db->delete('name');
-        $this->assertFalse($db->get('name'));
-        $this->assertEquals($arr, $db->get('arr'));
+    /**
+     * @dataProvider testDatabaseProvider
+     */
+    public function testDelete($dbname, $config)
+    {
+        $db = Flintstone::load($dbname, $config);
+        $this->assertFalse($db->get('foo'));
+        $db->set('foo', 1);
+        $this->assertEquals(1, $db->get('foo'));
+        $db->delete('foo');
+        $this->assertFalse($db->get('foo'));
+        unlink($db->getDatabase()->getPath());
+    }
 
-        $keys = $db->getKeys();
-        $this->assertEquals(2, count($keys));
-        $this->assertEquals('foo', $keys[0]);
-        $this->assertEquals('arr', $keys[1]);
-
-        $data = $db->getAll();
-        $this->assertEquals(2, count($data));
-        $this->assertEquals(2, $data['foo']);
-        $this->assertEquals($arr, $data['arr']);
-
+    /**
+     * @dataProvider testDatabaseProvider
+     */
+    public function testFlush($dbname, $config)
+    {
+        $db = Flintstone::load($dbname, $config);
+        $this->assertFalse($db->get('foo'));
+        $db->set('foo', 1);
+        $this->assertEquals(1, $db->get('foo'));
         $db->flush();
         $this->assertFalse($db->get('foo'));
-        $this->assertFalse($db->get('arr'));
-        $this->assertEquals(0, count($db->getKeys()));
-        $this->assertEquals(0, count($db->getAll()));
+        unlink($db->getDatabase()->getPath());
+    }
 
+    /**
+     * @dataProvider testDatabaseProvider
+     */
+    public function testGetKeys($dbname, $config)
+    {
+        $db = Flintstone::load($dbname, $config);
+
+        $arr = array('foo' => "new\nline");
+        $db->set('foo', 1);
+        $db->set('name', 'john');
+        $db->set('arr', $arr);
+
+        $this->assertEquals(['foo', 'name', 'arr'], $db->getKeys());
+        unlink($db->getDatabase()->getPath());
+    }
+
+
+    /**
+     * @dataProvider testDatabaseProvider
+     */
+    public function testGetAll($dbname, $config)
+    {
+        $db = Flintstone::load($dbname, $config);
+
+        $arr = array('foo' => "new\nline");
+        $db->set('foo', 1);
+        $db->set('name', 'john');
+        $db->set('arr', $arr);
+
+        $result = $db->getAll();
+
+        $this->assertCount(3, $result);
+        $this->assertContains($arr, $result);
         unlink($db->getDatabase()->getPath());
     }
 }

--- a/tests/FlintstoneTest.php
+++ b/tests/FlintstoneTest.php
@@ -158,7 +158,7 @@ class FlintstoneTest extends PHPUnit_Framework_TestCase
         $db->set('name', 'john');
         $db->set('arr', $arr);
 
-        $this->assertEquals(['foo', 'name', 'arr'], $db->getKeys());
+        $this->assertEquals(array('foo', 'name', 'arr'), $db->getKeys());
         unlink($db->getDatabase()->getPath());
     }
 


### PR DESCRIPTION
The goal is to reduce cognitive learning and to improve code maintainability. The following were done:

- The Config class is now Immutable. Every change made to the config create a new config object instead of updating the currently used. You can chain setter methods 

```php
$config = (new Config())->withExtension('.db')->wihCache(new NullCache());
```

- The Array indexes are no longer abbreviated as the method names too.

```php
$config = (new Config(['extension' => 'db']))->withDirectory(__DIR__);
```

- To take advantage of  PHP Type Hinting the `Formatter` and `Cache` setter no longer
takes anything other than an object which implements the corresponding interface

```php
use Flintstone\Cache\NullCache;
use Flintstone\Config;
$config = (new Config())->withCache(new NullCache()); //to work without a Cache
```

- Some settings have been improved.

```php
$config = (new Config())->withGzip(true)->withExtension('.db');
$config->getExtension(); //return '.db'; // the gzip suffix is no longer append!!
$config->withSwapMemoryLimit(-24); //Throw an Exception
```

The `Database` object was also updated to take into account this changes and is also made immutable. Changing the  `Database` name or `Config` object will return a new object instead of modifying the current object.


```php
$database = Database::load('test', [
    'extension' => '.db',
    'cache' => new ArrayCache(),
]);
$altDatabase = $database->withName('bar');
```

There are less `Database` public methods (ie `Database::openFile`, `Database::closeFile` methods are no longer accessible from outside).
- The `Database::getPath` method was improve as a consequence of `Config::getExtension` no longer appending the gzip information when present.

```php
$database = Database::load('test', [
    'extension' => '.db',
    'cache' => new ArrayCache(),
    'useGzip' => true,
    'directory' => '/tmp',
]);
$altDatabase = $database->getPath(); //returns '/tmp/test.db.gz'
```

- The `Flintstone` object no longer let you set a `Database` once instantiated.

The test suite was also modified according to the changes.

