### PR TITLE
Change validation

### DIFF
--- a/src/Validation.php
+++ b/src/Validation.php
@@ -13,7 +13,7 @@ class Validation
      */
     public static function validateKey($key)
     {
-        if (empty($key) || !preg_match('/^[\w-]+$/', $key)) {
+        if (empty($key) || !preg_match('/^[\S-]+$/', $key)) {
             throw new Exception('Invalid characters in key');
         }
     }

--- a/tests/FlintstoneTest.php
+++ b/tests/FlintstoneTest.php
@@ -23,7 +23,7 @@ class FlintstoneTest extends PHPUnit_Framework_TestCase
     public function testKeyInvalidName()
     {
         $db = new Flintstone('test', []);
-        $db->get('test!123');
+        $db->get('test 123');
     }
 
     /**

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -10,7 +10,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase
      */
     public function testValidateKey()
     {
-        Validation::validateKey('test!123');
+        Validation::validateKey('test 123');
     }
 
     /**
@@ -28,6 +28,6 @@ class ValidationTest extends PHPUnit_Framework_TestCase
      */
     public function testValidateDatabaseName()
     {
-        Validation::validateDatabaseName('test!123');
+        Validation::validateDatabaseName('test 123');
     }
 }


### PR DESCRIPTION
Change validation so to allow any non-whitespace character as key name. Honestly I'm not sure if there is any reason as to why only letters and numbers were allowed, but I had no issues using this approach locally (that is, until 2.1 was released which brok the storage system and wiped all my data :( not cool)