### PR TITLE
Make database config type explicitly nullable (fix php84 deprecation)

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -68,7 +68,7 @@ class Database
      * @param string $name
      * @param Config|null $config
      */
-    public function __construct(string $name, Config $config = null)
+    public function __construct(string $name, Config|null $config = null)
     {
         $this->setName($name);
 


### PR DESCRIPTION
In PHP 8.4 nullable parameters have to be made [explicitly nullable](https://www.php.net/manual/en/migration84.deprecated.php). This PR fixes that for the `Config` parameter in the `Database` class. 